### PR TITLE
update quay project, remove experimental squash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PROJECT   ?= quay-builder
 ORG_PATH  ?= github.com/quay
 REPO_PATH ?= $(ORG_PATH)/$(PROJECT)
-IMAGE     ?= quay.io/quay/$(PROJECT)
+IMAGE     ?= quay.io/projectquay/$(PROJECT)
 VERSION   ?= $(shell ./scripts/git-version)
 LD_FLAGS  ?= "-w -X $(REPO_PATH)/version.Version=$(VERSION)"
 IMAGE_TAG ?= latest
@@ -28,10 +28,10 @@ install:
 	@go install -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/quay-builder
 
 build-centos7:
-	docker build --squash -f Dockerfile.centos7 -t $(IMAGE):$(IMAGE_TAG)-centos7 .
+	docker build -f Dockerfile.centos7 -t $(IMAGE):$(IMAGE_TAG)-centos7 .
 
 build-rhel7:
-	docker build --squash -f Dockerfile.rhel7 -t $(IMAGE):$(IMAGE_TAG)-rhel7 . \
+	docker build -f Dockerfile.rhel7 -t $(IMAGE):$(IMAGE_TAG)-rhel7 . \
 		--build-arg SUBSCRIPTION_KEY=$(SUBSCRIPTION_KEY)
 
 build-alpine:


### PR DESCRIPTION
This PR removes the need for experimental features when building with docker and updates the docker image name with the new projectquay namespace. 

Signed-off-by: ldelossa <ldelossa@redhat.com>