### PR TITLE
Manually append cert to bundle

### DIFF
--- a/load_extra_ca.rhel.sh
+++ b/load_extra_ca.rhel.sh
@@ -8,3 +8,6 @@ if [ "$(ls -A /certs)" ]; then
 fi
 
 update-ca-trust extract
+
+# Update the defaule bundle to link to the newly generated bundle (not sure why /etc/pki/ca-trust/extracted/pem is not being updated...)
+cat /certs/ssl.cert >> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
For some reason, update-ca-trust extract does not update the default
bundle used by most programs (including Go):
/etc/pki/ca-trust/extracted/pem/...

It is instead updating /etc/pki/ca-trust/extracted/openssl/..., which
are not used by default by most program.