### PR TITLE
rpc: skip phase updates on checking cache and priming cache step

### DIFF
--- a/rpc/grpcbuild/grpcbuild.go
+++ b/rpc/grpcbuild/grpcbuild.go
@@ -170,6 +170,9 @@ func (c *grpcClient) PublishBuildLogEntry(entry string) error {
 			LogMessage:     entry,
 		},
 	)
+	if err == io.EOF {
+		return nil
+	}
 	if err != nil {
 		log.Warningf("failed to get log message: %s", err)
 		c.logSequenceNum -= 1


### PR DESCRIPTION
These steps are mapped to the same phase as pulling, and therefore
won't be seen as changed from Quay.