### PR TITLE
dockerfile: Switch base images to registry.access.redhat.com (PROJQUAY-3349)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.redhat.io/rhel8/go-toolset:1.16.12-4 as build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-4 as build
 USER root
 RUN dnf install -y --setopt=tsflags=nodocs git
 COPY . /go/src/
 RUN cd /go/src/ && env GOOS=linux GOARCH=amd64 make build
 
 
-FROM registry.redhat.io/ubi8/podman:8.5-15
+FROM registry.access.redhat.com/ubi8/podman:8.5-15
 LABEL maintainer "Quay devel<quay-devel@redhat.com>"
 
 RUN set -ex\


### PR DESCRIPTION

Removes the need to specify auth in pipelines.