### PR TITLE
buildpack: increase git command timeout (PROJQUAY-3654)

### DIFF
--- a/buildpack/buildpack.go
+++ b/buildpack/buildpack.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	quayDocsSubmoduleURL = "http://docs.quay.io/guides/git-submodules.html"
-	processIdleTimeout   = time.Minute
+	processIdleTimeout   = time.Minute * 3
 	processTimeout       = time.Minute * 15
 )
 


### PR DESCRIPTION
Prevent the process being killed on larger `git clone` commands.