### PR TITLE
chore: downgrade ubi8/go-toolset version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset as build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 as build
 USER root
 RUN dnf install -y --setopt=tsflags=nodocs git
 COPY . /go/src/


### PR DESCRIPTION
Latest go-toolset 1.19.10-10.1692783630 image has a bug causing failure to build an image