### PR TITLE
Chore: Wide open ssh fix and non root user addition

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -33,6 +33,21 @@ jobs:
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
           echo "::set-output name=version::${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}"
 
+      - name: install ibmcli and setup ibm login
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          ibmcloud login -q --apikey ${{ secrets.IBMCLOUD_API_KEY }} -r eu-gb
+          ibmcloud plugin install vpc-infrastructure
+
+      - name: Add rule to VPC
+        id: sg-rule-id
+        run: |
+          cidr=$(dig +short myip.opendns.com @resolver1.opendns.com)
+          echo $cidr
+          SGRID=$(ibmcloud is security-group-rule-add --sg ${{ secrets.SG_ID }} --direction=inbound --protocol=tcp --port-min=22 --port-max=22 --remote=$cidr --output JSON | jq -r '.id')
+          echo $SGRID
+          echo "RID=${SGRID}" >> $GITHUB_ENV
+
       - name: Setup SSH config for builders
         env:
           BUILDER_PPC64LE_SSH_CONFIG: ${{ secrets.BUILDER_PPC64LE_SSH_CONFIG }}
@@ -94,3 +109,7 @@ jobs:
           file: Dockerfile
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
 
+      - name: Clean up
+        if: success() || failure()
+        run: |
+          ibmcloud is security-group-rule-delete ${{ secrets.SG_ID }} $RID -f


### PR DESCRIPTION
Added steps to install IBM CLI, log in, and manage VPC security group rules.
This fix was merged to quay repo previously in this [PR](https://github.com/quay/quay/pull/3591)

Note: Below secrets must be added/update for s390x

$BUILDER_S390X_SSH_CONFIG
$SG_ID
