### PR TITLE
NO-ISSUE: fix(ci): pin s390x buildkit to v0.30.0 to avoid runc masking regression

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -95,6 +95,9 @@ jobs:
               platforms: linux/ppc64le
             - endpoint: ssh://builder-s390x
               platforms: linux/s390x
+              # Remove this pin once a BuildKit image ships runc >= 1.5.1.
+              driver-opts:
+                - image=moby/buildkit:v0.30.0
 
       - name: Login to Quay.io
         uses: docker/login-action@v1


### PR DESCRIPTION
## Summary
- Pin the s390x BuildKit builder to `moby/buildkit:v0.30.0` to work around a `runc` regression that prevents container init from masking `/sys/firmware`
- Same fix as quay/quay#6703, applied to quay-builder

## Test plan
- [ ] Verify s390x multi-arch build succeeds with pinned BuildKit version