### PR TITLE
[redhat-3.12] NO-ISSUE: fix(ci): pin s390x buildkit to v0.30.0 to avoid runc masking regression

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -95,6 +95,9 @@ jobs:
               platforms: linux/ppc64le
             - endpoint: ssh://builder-s390x
               platforms: linux/s390x
+              # Remove this pin once a BuildKit image ships runc >= 1.5.1.
+              driver-opts:
+                - image=moby/buildkit:v0.30.0
 
       - name: Login to Quay.io
         uses: docker/login-action@v1


### PR DESCRIPTION
## Summary

Cherry-pick of quay/quay-builder#664 for `redhat-3.12`.

Pin the s390x BuildKit node in `build-and-publish.yaml` to
`moby/buildkit:v0.30.0` instead of the default floating
`moby/buildkit:buildx-stable-1` tag.

Same fix as quay/quay#6703, applied to quay-builder.

### Root cause

s390x image builds began failing at container init on every `RUN` step:

```
runc run failed: unable to start container process: error during container
init: can't mask dir "/sys/firmware": mount src=tmpfs, dst=/sys/firmware,
flags=MS_RDONLY, data=nr_blocks=1,nr_inodes=1: invalid argument
```

The failure came from an upstream image tag drifting onto a regressed runc:

- The builder uses the docker-container driver, so `RUN` steps execute with the
  runc **bundled inside the `moby/buildkit` image**, not the host's runc.
- The workflow was unpinned, so it used buildx's default `buildx-stable-1` tag,
  which is periodically republished.
- runc **1.4.3 / 1.3.6** (2026-06-13) started mounting the masking tmpfs with
  `nr_inodes=1`. The s390x builder runs Ubuntu Focal, kernel
  `5.4.0-216-generic`, whose tmpfs rejects `nr_inodes=1` with `EINVAL`.
- Once `buildx-stable-1` rolled forward onto that runc, every s390x build broke.
  amd64 was unaffected because the GitHub runner's newer kernel accepts the mount.

### Fix

The upstream fix (nr_inodes=2 fallback, runc PR opencontainers/runc#5358) only shipped in runc
**1.5.1**, which no BuildKit release bundles yet — the latest `v0.32.0` still
ships runc 1.4.3. So we pin **backward** to `v0.30.0`, the newest BuildKit that
bundles a pre-regression runc (**1.3.5**) while retaining the Nov-2025 CVE fixes.

### Source PRs

| Repo | Branch | PR | Status |
|---|---|---|---|
| quay/quay | master | quay/quay#6703 | Merged |
| quay/quay-builder | master | quay/quay-builder#664 | Merged |
| quay/quay-builder | redhat-3.19 | quay/quay-builder#669 | Open |
| quay/quay-builder | redhat-3.18 | quay/quay-builder#666 | Merged |
| quay/quay-builder | redhat-3.17 | quay/quay-builder#670 | Open |
| quay/quay-builder | redhat-3.16 | quay/quay-builder#671 | Open |
| quay/quay-builder | redhat-3.15 | quay/quay-builder#665 | Merged |
| quay/quay-builder | redhat-3.14 | quay/quay-builder#672 | Open |
| quay/quay-builder | redhat-3.9 | quay/quay-builder#667 | Merged |
| **quay/quay-builder** | **redhat-3.12** | **This PR** | Open |

### References

- runc opencontainers/runc#5348 — same `5.4.0-216-generic` kernel; 1.4.2 works, 1.4.3 breaks
- runc opencontainers/runc#5358 — nr_inodes=2 fallback fix (shipped in runc 1.5.1)
- moby/moby moby/moby#52972 — same regression via Docker
- Failed release build: https://github.com/quay/releases/actions/runs/31121543587

## Test plan

- [ ] Verify s390x multi-arch build succeeds with pinned BuildKit version

Made with [Cursor](https://cursor.com)