### PR TITLE
Add coverage target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/*
 /bin/
 _vendor*
 *.test
+coverage.*

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ vendor:
 
 test: vendor
 	@go vet ./...
-	@go test -v ./...
+	@go test -v -covermode=atomic -coverprofile=coverage.out ./...
+
+coverage: test
+	@go tool cover -func=coverage.out -o coverage.txt
+	@go tool cover -html=coverage.out -o coverage.html
 
 build: bin/quay-builder
 


### PR DESCRIPTION
Run `make coverage` to generate a coverage report.

- Modification to `make test` to generate a coverage profile
- Coverage artifacts are ignored by git