### PR TITLE
Update for deprecated ioutils imports

### DIFF
--- a/buildpack/buildpack.go
+++ b/buildpack/buildpack.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -97,7 +96,7 @@ func download(url string) (string, error) {
 // extractToTempDir extracts a body into a temporary directory and returns the path.
 func extractToTempDir(body io.Reader, xtractor extractor.Extractor) (string, error) {
 	// Create a temporary file.
-	archiveFile, err := ioutil.TempFile("", "build_archive")
+	archiveFile, err := os.CreateTemp("", "build_archive")
 	if err != nil {
 		return "", err
 	}
@@ -111,7 +110,7 @@ func extractToTempDir(body io.Reader, xtractor extractor.Extractor) (string, err
 	}
 
 	// Create a temporary directory for the build pack.
-	tempDir, err := ioutil.TempDir("", "build_pack")
+	tempDir, err := os.MkdirTemp("", "build_pack")
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +127,7 @@ func extractToTempDir(body io.Reader, xtractor extractor.Extractor) (string, err
 // dockerfileTempDir creates a temporary directory, copying over the dockerfile.
 func dockerfileTempDir(dockerfile io.Reader) (string, error) {
 	// Create a directory containing the Dockerfile directly.
-	tempDir, err := ioutil.TempDir("", "build_pack")
+	tempDir, err := os.MkdirTemp("", "build_pack")
 	if err != nil {
 		return "", err
 	}
@@ -141,7 +140,7 @@ func dockerfileTempDir(dockerfile io.Reader) (string, error) {
 	defer fo.Close()
 
 	// Read the Dockerfile bytes.
-	bytes, err := ioutil.ReadAll(dockerfile)
+	bytes, err := io.ReadAll(dockerfile)
 	if err != nil {
 		return "", err
 	}
@@ -190,7 +189,7 @@ func extractBuildPackage(body io.Reader, mimetype string) (string, error) {
 // Clone creates a temporary directory and `git clone`s a repository into it.
 func Clone(url, sha, privateKey string) (string, error) {
 	// Create a temp file for the ssh key.
-	keyFile, err := ioutil.TempFile("", "ssh_key")
+	keyFile, err := os.CreateTemp("", "ssh_key")
 	if err != nil {
 		return "", err
 	}
@@ -215,7 +214,7 @@ func Clone(url, sha, privateKey string) (string, error) {
 	}
 
 	// Create a temp directory to clone the buildpack into.
-	bpPath, err := ioutil.TempDir("", "build_pack")
+	bpPath, err := os.MkdirTemp("", "build_pack")
 	if err != nil {
 		return "", err
 	}

--- a/buildpack/buildpack_test.go
+++ b/buildpack/buildpack_test.go
@@ -2,7 +2,6 @@ package buildpack
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -61,7 +60,7 @@ func TestDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile(filepath.Join(path, "Dockerfile"))
+	b, err := os.ReadFile(filepath.Join(path, "Dockerfile"))
 	if err != nil {
 		t.Error(err)
 	} else if string(b) != "#(nop): test\n" {

--- a/cmd/quay-builder/tls.go
+++ b/cmd/quay-builder/tls.go
@@ -3,7 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 )
 
 const serverName = "quay-services"
@@ -26,7 +26,7 @@ func LoadTLSClientConfig(certFile, keyFile, caFile string) (*tls.Config, error) 
 
 	var caCertPool *x509.CertPool
 	if caFile != "" {
-		caCert, err := ioutil.ReadFile(caFile)
+		caCert, err := os.ReadFile(caFile)
 		if err != nil {
 			return nil, err
 		}

--- a/containerclient/docker_client.go
+++ b/containerclient/docker_client.go
@@ -3,7 +3,6 @@ package containerclient
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,7 +12,7 @@ import (
 
 func buildTLSTransport(basePath string) (*http.Transport, error) {
 	roots := x509.NewCertPool()
-	pemData, err := ioutil.ReadFile(basePath + "/ca.pem")
+	pemData, err := os.ReadFile(basePath + "/ca.pem")
 	if err != nil {
 		return nil, err
 	}

--- a/containerclient/docker_log_writer.go
+++ b/containerclient/docker_log_writer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"runtime"
 
 	log "github.com/sirupsen/logrus"
@@ -73,7 +72,7 @@ func (w *DockerRPCWriter) Write(p []byte) (n int, err error) {
 			// Docker was too large to fit into the single Write call. Therefore, we
 			// store any unparsed data and prepend it on the next call.
 			var bufferedData []byte
-			bufferedData, err = ioutil.ReadAll(dec.Buffered())
+			bufferedData, err = io.ReadAll(dec.Buffered())
 			if err != nil {
 				log.Fatalf("Error when reading buffered logs: %v", err)
 			}
@@ -81,7 +80,7 @@ func (w *DockerRPCWriter) Write(p []byte) (n int, err error) {
 			break
 		} else if err != nil {
 			// Try to determine what we failed to decode.
-			entry, readErr := ioutil.ReadAll(dec.Buffered())
+			entry, readErr := io.ReadAll(dec.Buffered())
 			if readErr != nil {
 				entry = []byte("unknown")
 			}


### PR DESCRIPTION
My text editor indicates on deprecated GO imports.

These were easy-fix:
- ioutil.TempFile --> os.CreateTemp
- ioutil.TempFile --> os.MkdirTemp
- ioutil.ReadAll --> io.ReadAll
- ioutil.ReadFile --> os.ReadFile

The only remaining deprecated thing involves Protobuf.
That code was auto generated, and warns not edit.

All this passed tests on my local machine, fedora-44.